### PR TITLE
Compiles with Visual Studio 2019 (#33)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,14 @@ set(resources ${data_files} ${support_files})
 add_executable(umoria ${source_files} ${resources})
 
 
+#
+# Get around the fact that Visual Studio doesn't have ssize_t
+# defined but uses SSIZE_T instead.
+#
+if(MSVC)
+    add_definitions(-Dssize_t=SSIZE_T)
+endif(MSVC)
+
 # This is horrible, but needed bacause `find_package()` doesn't use the
 # include/lib inside the /mingw32 or /mingw64 directories, and with
 # `ncurses-devel` installed, it won't compile.

--- a/src/curses.h
+++ b/src/curses.h
@@ -13,7 +13,15 @@
 #ifdef _WIN32
   // this is defined in Windows and also in ncurses
   #undef KEY_EVENT
-  #include <ncurses/ncurses.h>
+  #ifdef _MSVC_LANG
+    // On Microsoft Visual Studio 2019, this constant also needs to
+    // be undefined.  Also, we need to use the PDCurses library rather
+    // than a system library, and it has a different include file name.
+    #undef MOUSE_MOVED
+    #include <curses.h>
+  #else
+    #include <ncurses/ncurses.h>
+  #endif
 #elif __NetBSD__
   #include <curses.h>
 #else

--- a/src/game_save.cpp
+++ b/src/game_save.cpp
@@ -876,7 +876,7 @@ bool loadGame(bool &generate) {
 
             if (panic_save) {
                 printMessage("This game is from a panic save.  Score will not be added to scoreboard.");
-            } else if ((!game.noscore) & 0x04) {
+            } else if ((~game.noscore) & 0x04) {
                 printMessage("This character is already on the scoreboard; it will not be scored again.");
                 game.noscore |= 0x4;
             }


### PR DESCRIPTION
* Modifications to get the project to compile and link on Visual Studio 2019 using the PDCurses library.
* Commenting the changes to the curses.h header file.
* Fixed bug with logical not rather than bitwise inversion caught by a compiler warning.